### PR TITLE
Feature/20825 better buffering

### DIFF
--- a/libavformat/http.c
+++ b/libavformat/http.c
@@ -1397,6 +1397,13 @@ static int http_buf_read(URLContext *h, uint8_t *buf, int size)
           len = ffurl_read(s->hd, s->buf_ptr, sizeof(s->buffer)-(s->buf_ptr - s->buffer));
           if (len > 0)
             s->buf_end = s->buf_ptr + len;
+	} else if (size < sizeof(s->buffer)/2) {
+	  // if size is less than half the buffer then shift it and keep the last half of the current buffer
+	  memcpy(s->buffer, s->buffer+sizeof(s->buffer)/2, (s->buf_end-s->buffer-sizeof(s->buffer)/2));
+	  s->buf_ptr -= sizeof(s->buffer)/2;
+          len = ffurl_read(s->hd, s->buf_ptr, sizeof(s->buffer)-(s->buf_ptr - s->buffer));
+          if (len > 0)
+            s->buf_end = s->buf_ptr + len;
         } else {
           // otherwise start on a new buffer
           len = ffurl_read(s->hd, s->buffer, sizeof(s->buffer));


### PR DESCRIPTION
This changes so we keep a 1MB buffer so we can do localised seeks back and forth without having to throw away all the data we have already read.

http_buf_read() reads data from the buffer if the requested data is there, and if not it tries to fill the buffer up to its maximum. If the requested read size can't be read without overflowing the buffer then the first half of the buffer gets thrown away and the second half is copied into the first half. The reason for this is that I saw several cases where it wanted to do a seek just after clearing the buffer. The last case is that if the requested read is longer than half the buffer size then we just clear the buffer to be on the safe side. 

An explanation of the variables used

* s->buffer is a static buffer allocated for each input (in struct HTTPContext)
* s->buf_ptr points to the next byte to be read
* s->off is the global offset in the file for the byte that s->buf_ptr points to
* s->buf_end is the last byte that is used in the buffer (a read from the network with ffurl_read often is shorter than the buffer length

